### PR TITLE
Fix/missing new columns on resize

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Don't be afraid to ask for more information.
 | nvim.go     | Implements the widget interface i.e. is the center of this project |
 | render.go   | Implements the renderer for our widget as required for custom widgets |
 | input.go    | Using the mappings from keymap.go this forwards inputs from Fyne to Neovim |
-| output.go   | Provides functions to write runes etc. to the textgrid which visualizes Neovim |
+| output.go   | Provides functions to write runes etc. to the textgrid which visualizes Neovim. Should only be used from the handler in events.go, as they are not implemented for concurrent use. |
 | events.go   | Process the events received from Neovim (uses output.go to forward visual changes to Fyne) |
 
 ### Resources

--- a/nvim.go
+++ b/nvim.go
@@ -120,8 +120,6 @@ func (n *NeoVim) startNeovim() error {
 
 // Override resize to adjust the textgrid
 func (n *NeoVim) Resize(s fyne.Size) {
-	n.BaseWidget.Resize(s) // must be included
-	n.content.Resize(s)
 	n.resizeGrid(s)
 }
 
@@ -131,6 +129,7 @@ func (n *NeoVim) resizeGrid(s fyne.Size) {
 	rowsCnt := int(s.Height / cellSize.Height)
 	colsCnt := int(s.Width / cellSize.Width)
 
+	// Triggers the resize event
 	err := n.engine.TryResizeUIGrid(GLOBAL_GRID, colsCnt, rowsCnt)
 	if err != nil {
 		fmt.Println("Error resizing grid: ", err)

--- a/output.go
+++ b/output.go
@@ -82,6 +82,8 @@ func (n *NeoVim) WriteGridLine(row, col int, cells []interface{}) {
 
 // Changes the size of the textgrid, creating or removing rows and columns as
 // needed
+// TODO: One may consider only downsizing rows/cols if the difference is
+// significant
 func (n *NeoVim) ChangeVisualGridSize(targetRow, targetCol int) {
 	// remove rows
 	if targetRow < len(n.content.Rows) {
@@ -99,7 +101,6 @@ func (n *NeoVim) ChangeVisualGridSize(targetRow, targetCol int) {
 		// remove columns
 		numCols := len(n.content.Rows[currRow].Cells)
 		if numCols > targetCol {
-			// TODO : this causes weird behavior
 			n.content.Rows[currRow].Cells =
 				n.content.Rows[currRow].Cells[:targetCol-1]
 		}

--- a/output.go
+++ b/output.go
@@ -19,6 +19,88 @@ func (n *NeoVim) fillGrid(row, col int, hl highlight) {
 	}
 }
 
+// Substitutes all runes with ' '
+func (n *NeoVim) ClearGrid() {
+	for i := range n.content.Rows {
+		for j := range n.content.Rows[i].Cells {
+			n.content.Rows[i].Cells[j].Rune = ' '
+		}
+	}
+}
+
+// Moves the displayed text up/down/lef/right
+func (n *NeoVim) ScrollGrid(top, bot, left, right, rows int) {
+	if rows > 0 {
+		// Scroll down
+		for row := top; row < bot-rows; row++ {
+			for col := left; col < right; col++ {
+				n.fillGrid(row, col, defaultHL)
+
+				cell := n.content.Rows[row+rows].Cells[col]
+				n.content.Rows[row].Cells[col] = cell
+			}
+		}
+	} else {
+		// Scroll up, start at bot-1 to skip the status line
+		for row := bot - 1; row > top+(-rows); row-- {
+			for col := left; col < right; col++ {
+				n.fillGrid(row, col, defaultHL)
+
+				cell := n.content.Rows[row+rows].Cells[col]
+				n.content.Rows[row].Cells[col] = cell
+			}
+		}
+	}
+}
+
+// Recovers the previous locations colors on horizontal movement and updates the
+// cursor position
+func (n *NeoVim) MoveGridCursor(oldRow, oldCol, newRow, newCol int) {
+	// recover the previous locations colors on horizontal movement
+	if oldRow == int(newRow) {
+		r := n.content.Rows[oldRow].Cells[oldCol].Rune
+		cellStyle := &widget.CustomTextGridStyle{
+			FGColor: n.cursorCellFg,
+			BGColor: n.cursorCellBg,
+		}
+		recoveredCell := widget.TextGridCell{Rune: r, Style: cellStyle}
+		n.content.SetCell(oldRow, oldCol, recoveredCell)
+	}
+
+	newCell := n.content.Rows[newRow].Cells[newCol]
+	n.cursorCellFg = newCell.Style.TextColor()
+	n.cursorCellBg = newCell.Style.BackgroundColor()
+	n.cursorRow = int(newRow)
+	n.cursorCol = int(newCol)
+}
+
+// Writes a line of text (as defined by neovims ui events) to the textgrid
+func (n *NeoVim) WriteGridLine(row, col int, cells []interface{}) {
+	lastHL_id := 0
+	for _, cell := range cells {
+		cell := cell.([]interface{})
+		s := cell[0].(string)
+		r := rune(s[0])
+
+		if len(cell) > 1 {
+			lastHL_id, _ = intOrUintToInt(cell[1])
+		}
+
+		repeat := 1
+		if len(cell) > 2 {
+			repeat, _ = intOrUintToInt(cell[2])
+		}
+
+		for i := 0; i < repeat; i++ {
+			n.writeRune(row, col, r, lastHL_id)
+			if len(s) > 1 {
+				n.writeRune(row, col, ' ', lastHL_id)
+			}
+			col++
+		}
+	}
+}
+
 // Writes a rune to the textgrid
 func (n *NeoVim) writeRune(row int, col int, r rune, hl_id int) {
 


### PR DESCRIPTION
**Problem :**
Since the resizing was done lazy i.e. rows/columns were only created when needed (which is actually done by textgrid.SetCell anyway) and nvim doesn't send complete grid_line updates after resize, some columns would remain uncolored.

**Fix :**
On resize create/remove rows/cols as needed.

**Additionally :**
the structure was refactored such that ALL textgrid manipulation is now done by functions implemented in `output.go`, which are exclusively called by the redraw event handler implemented in `events.go`, as it is called by the neovim go-client sequentially (i.e. no concurrency issues will arise) 